### PR TITLE
Always write run.dat

### DIFF
--- a/psmc_check.py
+++ b/psmc_check.py
@@ -484,22 +484,30 @@ def config_logging(outdir, verbose):
     rootlogger = logging.getLogger()
     rootlogger.addHandler(NullHandler())
 
+    logger = logging.getLogger('psmc_check')
+    logger.setLevel(logging.DEBUG)
+
+    # Get loglevel for console output
     loglevel = {0: logging.CRITICAL,
                 1: logging.INFO,
                 2: logging.DEBUG}.get(verbose, logging.INFO)
-
-    logger = logging.getLogger('psmc_check')
-    logger.setLevel(loglevel)
 
     formatter = logging.Formatter('%(message)s')
 
     console = logging.StreamHandler()
     console.setFormatter(formatter)
+    console.setLevel(loglevel)
     logger.addHandler(console)
 
     filehandler = logging.FileHandler(
         filename=os.path.join(outdir, 'run.dat'), mode='w')
     filehandler.setFormatter(formatter)
+    # Set the file loglevel to be at least INFO,
+    # but override to DEBUG if that is requested at the
+    # command line
+    filehandler.setLevel(logging.INFO)
+    if loglevel == logging.DEBUG:
+        filehandler.setLevel(logging.DEBUG)
     logger.addHandler(filehandler)
 
 


### PR DESCRIPTION
Change loglevel handling so "verbose=0" doesn't make an empty
run.dat and instead only silences the console log output.
run.dat will now have INFO level text or will pay attention
to the verbose option only if it is set at DEBUG.
