### PR TITLE
Pin1at fix

### DIFF
--- a/psmc_check.py
+++ b/psmc_check.py
@@ -278,7 +278,8 @@ def make_week_predict(opt, tstart, tstop, bs_cmds, tlm, db):
         ok = ((tlm['date'] >= state0['tstart'] - 700) &
               (tlm['date'] <= state0['tstart'] + 700))
         state0.update({'T_psmc': np.mean(tlm['1pdeaat'][ok])})
-        state0.update({'T_pin1at': np.mean(tlm['1pin1at'][ok]) + 3.0 })
+        # state0.update({'T_pin1at': np.mean(tlm['1pin1at'][ok]) + 3.0 })
+        state0.update({'T_pin1at': np.mean(tlm['1pdeaat'][ok]) - 10.0 })
 
         
 

--- a/psmc_check.py
+++ b/psmc_check.py
@@ -701,10 +701,17 @@ def make_check_plots(opt, states, times, temps, tstart):
         y2=pointpair(states['simpos']),
         ylabel2='SIM-Z (steps)',
         ylim2=(-105000, 105000),
+        figsize=(7.5,3.5),
         )
     plots['pow_sim']['ax'].axvline(load_start, linestyle=':', color='g',
                                    linewidth=1.0)
-    plots['pow_sim']['fig'].subplots_adjust(right=0.85)
+    # The next several lines ensure that the width of the axes
+    # of all the weekly prediction plots are the same.
+    w1, h1 = plots['psmc']['fig'].get_size_inches()
+    w2, h2 = plots['pow_sim']['fig'].get_size_inches()
+    lm = plots['psmc']['fig'].subplotpars.left*w1/w2
+    rm = plots['psmc']['fig'].subplotpars.right*w1/w2
+    plots['pow_sim']['fig'].subplots_adjust(left=lm, right=rm)
     filename = 'pow_sim.png'
     outfile = os.path.join(opt.outdir, filename)
     logger.info('Writing plot file %s' % outfile)


### PR DESCRIPTION
Changing from 1PIN1AT+3 to 1PDEAAT-10 to initialize the temperature of the extra node pin1at.

This is because 1PIN1AT is no longer reliable (as of Apr 1, 2016), but it tracked 1PDEAAT with an offset of about -13 C. The effects are subtle (about a degree in the predicted 1PDEAAT model) and die away after a few hours from the start of the simulation.

Also adjusted the width of the 2nd plot on the output page to match the first. This follows a commit done in dea_check precisely.