### PR TITLE
2017 fit to model with DA heater off

### DIFF
--- a/psmc_model_spec.json
+++ b/psmc_model_spec.json
@@ -31,10 +31,14 @@
         [
             "2015:264:04:35:00", 
             "2015:266:05:00:00"
-        ],
+        ], 
         [
             "2016:063:17:11:00", 
             "2016:065:04:27:00"
+        ], 
+        [
+            "2016:344:07:40:00", 
+            "2016:346:00:00:00"
         ]
     ], 
     "comps": [
@@ -182,7 +186,7 @@
                         1.476175
                     ]
                 ], 
-                "epoch": "2015:250"
+                "epoch": "2016:322"
             }, 
             "name": "psmc_solarheat__pin1at"
         }, 
@@ -257,12 +261,12 @@
             "name": "dpa_power"
         }
     ], 
-    "datestart": "2015:175:12:05:20.816", 
-    "datestop": "2016:010:11:49:20.816", 
+    "datestart": "2016:202:12:02:24.816", 
+    "datestop": "2017:076:11:54:08.816", 
     "dt": 328.0, 
     "gui_config": {
         "autoscale": false, 
-        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/fit3_psmc_spec.json", 
+        "filename": "/data/marple1/chandra/acis/thermal_models/psmc_models/2017_03_01/psmc_fitme2.json", 
         "plot_names": [
             "1pdeaat data__time", 
             "1pdeaat resid__time", 
@@ -314,22 +318,22 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_45", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_45", 
-            "val": 1.9747709788205023
+            "val": 1.7768805464596165
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_55", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_55", 
-            "val": 1.869583686318248
+            "val": 1.7438986880908875
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -339,7 +343,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_65", 
-            "val": 1.5975451513949868
+            "val": 1.9439420234910501
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -349,7 +353,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_75", 
-            "val": 2.0808163664155854
+            "val": 1.8104849363626516
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -359,7 +363,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_85", 
-            "val": 0.88362633628040865
+            "val": 1.7549943028497204
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -369,27 +373,27 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_95", 
-            "val": 1.9959530309542404
+            "val": 1.8326918995183772
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_130", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_130", 
-            "val": 2.2898603709308514
+            "val": 2.4394676847724805
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_170", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_170", 
-            "val": 2.6836579308120476
+            "val": 2.7652593224891655
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -399,7 +403,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_45", 
-            "val": 2.5598752928973343
+            "val": 2.6534128155686414
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -409,7 +413,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_55", 
-            "val": 2.8481774981275567
+            "val": 2.3057315364164377
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -419,7 +423,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_65", 
-            "val": 1.9861723911280034
+            "val": 2.3599740063935508
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -429,7 +433,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_75", 
-            "val": 1.1949533094228291
+            "val": 2.2999999999999998
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -439,7 +443,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_85", 
-            "val": 1.6296758041996964
+            "val": 2.2999999999999998
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -449,27 +453,27 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_95", 
-            "val": 1.5088402341160105
+            "val": 1.8208639772257142
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrci_130", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_130", 
-            "val": 2.2499176448845155
+            "val": 2.3934309313337971
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_hrci_170", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_170", 
-            "val": 1.8632983793564364
+            "val": 2.5541519969038786
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -539,7 +543,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_130", 
-            "val": 1.7680952950863937
+            "val": 1.9130589194319412
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -549,7 +553,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_170", 
-            "val": 1.9946246537499412
+            "val": 2.214118410890312
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -619,7 +623,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_130", 
-            "val": 1.7358836517501319
+            "val": 1.8749433476497748
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -629,7 +633,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_170", 
-            "val": 1.8992638560367361
+            "val": 2.1531522492876745
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -734,12 +738,12 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dh_heater", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dh_heater", 
-            "val": 0.17201361253421638
+            "val": -0.63005084251215315
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
@@ -749,7 +753,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": 0.32077916679488183
+            "val": 0.34784384942788771
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
@@ -759,7 +763,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -2.6565239425807667
+            "val": -2.5834858048564042
         }, 
         {
             "comp_name": "heatsink__pin1at", 
@@ -789,7 +793,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_0xxx", 
-            "val": 24.707315903733697
+            "val": 21.077372144111251
         }, 
         {
             "comp_name": "dpa_power", 


### PR DESCRIPTION
The 1PDEAAT model of a thermistor on the ACIS PSMC box is in need
of an update. The model as constituted uses a single-parameter to
represent the power dissapated by the detector housing heater,
which was on from 2015:223 through 2016:202, during which the
current calibration of the model was done. The most recent addition
to the physics of the model was to incorporate the effects of
off-nominal roll, in a version released in Jan, 2016.

The problem is that, since it's governed by a thermostat, the
detector housing heater draws more current in attitudes when
the camera body would be cold (i.e. forward pitch), and less
(down to zero) when there's sun on the aft end of the SIM. This
was put into the model by varying the pitch-sensitive solar heating
parameters. Since those also are high in forward pitch attitudes
and low at aft pitch, this has the effect of over-estimating the
dependence of solar heating on the pitch angle.

It is therefore necessary to recalibrate the model now that the
detector housing heater is off, presumably for the forseeable
future.

It has also been noticed that in some cases of two or three
ACIS chips clocking, the existing model shows systematic problems,
we think because of inadequate data against which to calibrate.
In addition, there were few HRC-I observations in the previous
calibration sets, but there are now a number of them, and so
the solar heating parameters for this SIM position were also fit.

Accordingly, I started with the currently-released model .json
file, and made a few hand edits, adding in safe modes and other
anomaly times when the commanded states and/or telemetry do not
accurately reflect the state of ACIS. I also set the epoch to
the center of the time being fit. This is not relevant, as it
appears to still not be necessary to have any time-dependence
to the solar heating for this system.

The model was fit to data from 2016:202 through 2017:076,
which is a period of 240 days. Since the end date, March 17, 2017,
we have had several more weeks worth of data to compare to the
new model.

I then thawed the pitch-sensitive heating parameters for one
SIM position at a time, fit them, and froze them again, repeating
the round-robin several times, and making manual adjustments to
get the pitch-dependence in the HRC-I and HRC-S SIM positions
to match closely. Some of the bins in the HRC-I position in particular
are not well constrained by the data.

In order to verify the new model, known internally as "f3" (standing for
"fit number 3"), I ran our psmc_check.py tool on 250 days ending at the
start of the APR1717 load. The median of the residuals (data minus model)
moved from -0.74 C to -0.05 C, essentially zero. Also, a number of large
negative excursions were eliminated, and the error histograms look much
more Gaussian. In these figures, the red histogram is for 1PDEAAT > 40 C,
while the blue one is for 1PDEAAT > 30 C.

The 1% and 99% quantiles changed from -4.60 and +4.21, respectively, to
-2.94 and +3.29, reflecting the tighter distribution of errors.

The baseline model error histogram:

![baseline_valid_hist](https://cloud.githubusercontent.com/assets/9807359/25293093/28040b62-26a7-11e7-89b6-1d81d41aaa83.png)

The new model error histogram:

![f3_valid_hist](https://cloud.githubusercontent.com/assets/9807359/25292655/176c9aaa-26a5-11e7-83bd-f1a6f2a613f1.png)

Also available are Matt's Dashboard plots, which he has created for
both models, and for two time-frames: one for 30 days and one for 180.
ending on or about April 4, 2017 (2017:094).

Baseline model 6-month dashboard plot:

![psmc_1pdeaat_model_dashboard_current_model_6-month](https://cloud.githubusercontent.com/assets/9807359/25293152/8568d378-26a7-11e7-909e-09fcf283715b.png)

New model 6-month dashboard plot:

![psmc_1pdeaat_model_dashboard_new_model_6-month](https://cloud.githubusercontent.com/assets/9807359/25293163/99e1e664-26a7-11e7-8f91-cbf4bbd624fc.png)

Baseline model 30-day dashboard plot:

![psmc_1pdeaat_model_dashboard_current_model_30-day](https://cloud.githubusercontent.com/assets/9807359/25293183/ae149c26-26a7-11e7-9b5d-ddba1fe69863.png)

New model 30-day dashboard lot:

![psmc_1pdeaat_model_dashboard_new_model_30-day](https://cloud.githubusercontent.com/assets/9807359/25293195/b9a83ef8-26a7-11e7-9d32-b892fb662f58.png)

The model is not perfect. As can be seen from the upper right corner
of the scatter plots on the dashboard figures, it sometimes underpredicts
hot cases by 2 to 3 C. The 99th percentile (heavy black line) at
high temperatures is about 2 C.

The planning limit for this MSID is +52.5 C, and the yellow limit
is +57.0 C, still well away from the planning limit plus 99% error.
The red limit is +62.0 C, far from any recent experience. The max
value reached since 2010 is 58.62 C, at the time we discovered
the system is sensitive to off-nominal roll in Nov 2015.

Lastly, here's a plot of the solar heating rate coefficients vs. pitch angle for the four instrument positions of the SIM translation table.

![guifit_screenshot](https://cloud.githubusercontent.com/assets/9807359/25293520/49b33d4e-26a9-11e7-911f-d81dd120a454.png)
