### PR TITLE
Update psmc_check to work with updated version of acis_thermal_check

### DIFF
--- a/psmc_check/__init__.py
+++ b/psmc_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 from .psmc_check import \
     calc_model

--- a/psmc_check/__init__.py
+++ b/psmc_check/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "1.0.1"
+
+from .psmc_check import \
+    calc_model

--- a/psmc_check/psmc_check.py
+++ b/psmc_check/psmc_check.py
@@ -69,7 +69,7 @@ def main():
                                   calc_model, args, other_telem=['1dahtbon'],
                                   other_map={'1dahtbon': 'dh_heater'})
     try:
-        psmc_check.driver()
+        psmc_check.run()
     except Exception as msg:
         if args.traceback:
             raise

--- a/psmc_check/psmc_check.py
+++ b/psmc_check/psmc_check.py
@@ -24,19 +24,13 @@ import xija
 from acis_thermal_check import \
     ACISThermalCheck, \
     calc_off_nom_rolls, \
-    get_options, \
-    make_state_builder, \
-    get_acis_limits, mylog
+    get_options, mylog
 import os
 import sys
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-yellow_hi, red_hi = get_acis_limits("1pdeaat")
-
-MSID = {"psmc":'1PDEAAT'}
-YELLOW = {"psmc": yellow_hi}
-MARGIN = {"psmc": 4.5}
+MSID = {"psmc": '1PDEAAT'}
 VALIDATION_LIMITS = {'1PDEAAT': [(1, 2.5), (50, 1.0), (99, 5.5)],
                      'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -88,13 +82,12 @@ class PSMCCheck(ACISThermalCheck):
 
 def main():
     args = get_options("psmc", model_path)
-    state_builder = make_state_builder(args.state_builder, args)
-    psmc_check = PSMCCheck("1pdeaat", "psmc", MSID, YELLOW,
-                           MARGIN, VALIDATION_LIMITS, HIST_LIMIT, 
-                           calc_model, other_telem=['1dahtbon'],
+    psmc_check = PSMCCheck("1pdeaat", "psmc", MSID, 
+                           VALIDATION_LIMITS, HIST_LIMIT, 
+                           calc_model, args, other_telem=['1dahtbon'],
                            other_map={'1dahtbon': 'dh_heater'})
     try:
-        psmc_check.driver(args, state_builder)
+        psmc_check.driver()
     except Exception as msg:
         if args.traceback:
             raise

--- a/psmc_check/psmc_check.py
+++ b/psmc_check/psmc_check.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 import matplotlib
 matplotlib.use('Agg')
 
-from astropy.io import ascii
-from Chandra.Time import date2secs
 import numpy as np
 import xija
 from acis_thermal_check import \
@@ -30,7 +28,6 @@ import sys
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-MSID = {"psmc": '1PDEAAT'}
 VALIDATION_LIMITS = {'1PDEAAT': [(1, 2.5), (50, 1.0), (99, 5.5)],
                      'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -64,8 +61,7 @@ def calc_model(model_spec, states, start, stop, T_psmc=None, T_psmc_times=None,
 
 def main():
     args = get_options("psmc", model_path)
-    psmc_check = ACISThermalCheck("1pdeaat", "psmc", MSID, 
-                                  VALIDATION_LIMITS, HIST_LIMIT, 
+    psmc_check = ACISThermalCheck("1pdeaat", "psmc", VALIDATION_LIMITS, HIST_LIMIT,
                                   calc_model, args, other_telem=['1dahtbon'],
                                   other_map={'1dahtbon': 'dh_heater'})
     try:

--- a/psmc_check/psmc_check.py
+++ b/psmc_check/psmc_check.py
@@ -38,8 +38,7 @@ VALIDATION_LIMITS = {'1PDEAAT': [(1, 2.5), (50, 1.0), (99, 5.5)],
 HIST_LIMIT = [30., 40.]
 
 def calc_model(model_spec, states, start, stop, T_psmc=None, T_psmc_times=None,
-               T_pin1at=None,T_pin1at_times=None,
-               dh_heater=None,dh_heater_times=None):
+               dh_heater=None, dh_heater_times=None):
     model = xija.XijaModel('psmc', start=start, stop=stop, model_spec=model_spec)
     times = np.array([states['tstart'], states['tstop']])
     model.comp['sim_z'].set_data(states['simpos'], times)
@@ -48,44 +47,27 @@ def calc_model(model_spec, states, start, stop, T_psmc=None, T_psmc_times=None,
     # 1PIN1AT is broken, so we set its initial condition
     # using an offset, which makes sense based on historical
     # data
-    if T_pin1at is None:
+    if T_psmc is None:
         T_pin1at = model.comp["1pdeaat"].dvals - 10.0
-    model.comp['pin1at'].set_data(T_pin1at,T_pin1at_times)
+    else:
+        T_pin1at = T_psmc - 10.0
+    model.comp['pin1at'].set_data(T_pin1at,T_psmc_times)
     model.comp['roll'].set_data(calc_off_nom_rolls(states), times)
     model.comp['eclipse'].set_data(False)
     for name in ('ccd_count', 'fep_count', 'vid_board', 'clocking', 'pitch'):
         model.comp[name].set_data(states[name], times)
-    model.comp['dh_heater'].set_data(dh_heater,dh_heater_times)
+    model.comp['dh_heater'].set_data(dh_heater, dh_heater_times)
     model.make()
     model.calc()
     return model
 
-class PSMCCheck(ACISThermalCheck):
-
-    def calc_model_wrapper(self, model_spec, states, tstart, tstop, state0=None):
-        if state0 is None:
-            start_msid = None
-            start_pin = None
-            dh_heater = None
-            dh_heater_times = None
-        else:
-            start_msid = state0[self.msid]
-            start_pin = state0[self.msid]-10.0 # the infamous pin1at hack
-            htrbfn = os.path.join(self.bsdir, 'dahtbon_history.rdb')
-            mylog.info('Reading file of dahtrb commands from file %s' % htrbfn)
-            htrb = ascii.read(htrbfn, format='rdb')
-            dh_heater_times = date2secs(htrb['time'])
-            dh_heater = htrb['dahtbon'].astype(bool)
-        return self.calc_model(model_spec, states, tstart, tstop, T_psmc=start_msid,
-                               T_psmc_times=None, T_pin1at=start_pin, T_pin1at_times=None,
-                               dh_heater=dh_heater, dh_heater_times=dh_heater_times)
 
 def main():
     args = get_options("psmc", model_path)
-    psmc_check = PSMCCheck("1pdeaat", "psmc", MSID, 
-                           VALIDATION_LIMITS, HIST_LIMIT, 
-                           calc_model, args, other_telem=['1dahtbon'],
-                           other_map={'1dahtbon': 'dh_heater'})
+    psmc_check = ACISThermalCheck("1pdeaat", "psmc", MSID, 
+                                  VALIDATION_LIMITS, HIST_LIMIT, 
+                                  calc_model, args, other_telem=['1dahtbon'],
+                                  other_map={'1dahtbon': 'dh_heater'})
     try:
         psmc_check.driver()
     except Exception as msg:

--- a/psmc_check/tests/conftest.py
+++ b/psmc_check/tests/conftest.py
@@ -1,9 +1,2 @@
-import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--answer_store",
-                     help="Generate new answers, but don't test. Argument is the directory to store the answers to.")
-
-@pytest.fixture()
-def generate_answers(request):
-    return request.config.getoption('--answer_store')
+from acis_thermal_check.regression_testing import \
+    pytest_addoption, answer_store

--- a/psmc_check/tests/test_psmc.py
+++ b/psmc_check/tests/test_psmc.py
@@ -10,5 +10,4 @@ psmc_rt = RegressionTester("1pdeaat", "psmc", model_path, VALIDATION_LIMITS,
                            HIST_LIMIT, calc_model, atc_kwargs=atc_kwargs)
 
 def test_psmc_loads(answer_store):
-    psmc_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                            answer_store)
+    psmc_rt.run_test_arrays(answer_store)

--- a/psmc_check/tests/test_psmc.py
+++ b/psmc_check/tests/test_psmc.py
@@ -1,12 +1,14 @@
-from ..psmc_check import psmc_check, model_path
+from ..psmc_check import VALIDATION_LIMITS, \
+    HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    load_test_template
-import os
+    RegressionTester
 
-default_model_spec = os.path.join(model_path, "psmc_model_spec.json")
+atc_kwargs = {"other_telem": ['1dahtbon'],
+              "other_map": {'1dahtbon': 'dh_heater'}}
 
-def test_psmc_may3016(answer_store):
-    run_start = "2016:122:12:00:00.000"
-    load_week = "MAY3016"
-    load_test_template("1pdeaat", "psmc", answer_store, run_start,
-                       load_week, default_model_spec, psmc_check)
+psmc_rt = RegressionTester("1pdeaat", "psmc", model_path, VALIDATION_LIMITS,
+                           HIST_LIMIT, calc_model, atc_kwargs=atc_kwargs)
+
+def test_psmc_loads(answer_store):
+    psmc_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                            answer_store)


### PR DESCRIPTION
This PR provides the updates to `psmc_check` to make it work with the new version of `acis_thermal_check` (PR acisops/acis_thermal_check#14). The result is a simplified code base and improved support for regression testing.

Highlights:

1. It is no longer necessary to subclass `ACISThermalCheck` and overload `calc_model_wrapper` because the detector housing heater logic is now handled by the superclass.
2. The yellow and margin limits are obtained using the `get_acis_limits` function internally in `ACISThermalCheck` and no longer need to be kept in this script.
3. It is no longer necessary for the script to construct the `StateBuilder` object as this now happens internally in `ACISThermalCheck`.
4. An updated regression test has been added which tests model outputs against validated answers for a number of loads.